### PR TITLE
Feature/prometheus ipmi exporter

### DIFF
--- a/docker/prometheus/prometheus-ipmi-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-ipmi-exporter/Dockerfile.j2
@@ -10,7 +10,7 @@ ENV ipmi_exporter_version=1.4.0
 {% endblock %}
 
 {% block ipmi_exporter_install %}
-RUN curl -sSL -o /tmp/ipmi_exporter.tar.gz https://github.com/prometheus-community/ipmi_exporter/releases/download/v${ipmi_exporter_version}/ipmi_exporter-${ipmi_exporter_version}.linux-${prometheus_arch}.tar.gz \
+RUN curl -sSL -o /tmp/ipmi_exporter.tar.gz https://github.com/prometheus-community/ipmi_exporter/releases/download/v${ipmi_exporter_version}/ipmi_exporter-${ipmi_exporter_version}.linux-{{debian_arch}}.tar.gz \
     && tar xvf /tmp/ipmi_exporter.tar.gz -C /opt/ \
     && rm -f /tmp/ipmi_exporter.tar.gz \
     && ln -s /opt/ipmi_exporter* /opt/ipmi_exporter


### PR DESCRIPTION
This adds a build for the prometheus-ipmi-exporter. I'm unsure if adding the dockerfile is all that's needed.