### PR TITLE
Add HAProxy hot reload post renewal hook

### DIFF
--- a/docker/letsencrypt/letsencrypt-certbot/Dockerfile.j2
+++ b/docker/letsencrypt/letsencrypt-certbot/Dockerfile.j2
@@ -29,6 +29,7 @@ RUN yum-config-manager --enable epel
     ] %}
 {% endif %}
 {{ macros.install_packages(letsencrypt_certbot_packages | customizable("packages")) }}
+COPY haproxy-reload.sh /etc/letsencrypt/renewal-hooks/post/haproxy-reload.sh
 
 {% block letsencrypt_certbot_footer %}{% endblock %}
 {% block footer %}{% endblock %}

--- a/docker/letsencrypt/letsencrypt-certbot/haproxy-reload.sh
+++ b/docker/letsencrypt/letsencrypt-certbot/haproxy-reload.sh
@@ -10,7 +10,7 @@ if [[ -d "$le_base" ]]; then
         # Start a transaction to update the certificate
         echo -e "set ssl cert $cert_path <<\n$(cat $le_base/$domain/fullchain.pem $le_base/$domain/privkey.pem | sed '/^[[:blank:]]*$/ d')\n" | socat /var/lib/kolla/haproxy/haproxy.sock -
         # Commit the transaction
-        echo -e "commit ssl cert $cert_path" | socat /var/lib/kolla/haproxy/haproxy.sock -
+        echo "commit ssl cert $cert_path" | socat /var/lib/kolla/haproxy/haproxy.sock -
     done
 fi
 

--- a/docker/letsencrypt/letsencrypt-certbot/haproxy-reload.sh
+++ b/docker/letsencrypt/letsencrypt-certbot/haproxy-reload.sh
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/bash 
 
 # Update HAProxy with new certs via its API
 

--- a/docker/letsencrypt/letsencrypt-certbot/haproxy-reload.sh
+++ b/docker/letsencrypt/letsencrypt-certbot/haproxy-reload.sh
@@ -1,0 +1,16 @@
+#!/bin/sh 
+
+# Update HAProxy with new certs via its API
+
+le_base=/etc/letsencrypt/live
+if [[ -d "$le_base" ]]; then
+    domains=$(find $le_base -mindepth 1 -type d -exec basename {} \;)
+    for domain in $domains; do
+        cert_path="/etc/haproxy/certs.d/$domain.pem"
+        # Start a transaction to update the certificate
+        echo -e "set ssl cert $cert_path <<\n$(cat $le_base/$domain/fullchain.pem $le_base/$domain/privkey.pem | sed '/^[[:blank:]]*$/ d')\n" | socat /var/lib/kolla/haproxy/haproxy.sock -
+        # Commit the transaction
+        echo -e "commit ssl cert $cert_path" | socat /var/lib/kolla/haproxy/haproxy.sock -
+    done
+fi
+

--- a/docker/letsencrypt/letsencrypt-certbot/haproxy-reload.sh
+++ b/docker/letsencrypt/letsencrypt-certbot/haproxy-reload.sh
@@ -7,8 +7,10 @@ if [[ -d "$le_base" ]]; then
     domains=$(find $le_base -mindepth 1 -type d -exec basename {} \;)
     for domain in $domains; do
         cert_path="/etc/haproxy/certs.d/$domain.pem"
+        # Get the full text of the certificate, deleting any blank lines (OpenSSL doesn't like those)
+        full_cert=$(cat $le_base/$domain/fullchain.pem $le_base/$domain/privkey.pem | sed '/^[[:blank:]]*$/ d')
         # Start a transaction to update the certificate
-        echo -e "set ssl cert $cert_path <<\n$(cat $le_base/$domain/fullchain.pem $le_base/$domain/privkey.pem | sed '/^[[:blank:]]*$/ d')\n" | socat /var/lib/kolla/haproxy/haproxy.sock -
+        echo -e "set ssl cert $cert_path <<\n$full_cert\n" | socat /var/lib/kolla/haproxy/haproxy.sock -
         # Commit the transaction
         echo "commit ssl cert $cert_path" | socat /var/lib/kolla/haproxy/haproxy.sock -
     done


### PR DESCRIPTION
Adds a post-renewal script to the `letsencrypt_certbot` container which automatically sends renewed certs to HAProxy via an exposed socket. This functionality is enabled via a change to HAProxy's config in https://github.com/ChameleonCloud/kolla-ansible/pull/30. Fixes https://github.com/ChameleonCloud/chi-in-a-box/issues/125
