### PR TITLE
Add prometheus_ironic_exporter

### DIFF
--- a/docker/ironic/ironic-conductor/Dockerfile.j2
+++ b/docker/ironic/ironic-conductor/Dockerfile.j2
@@ -95,6 +95,7 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 {% set ironic_conductor_pip_packages = [
     '-r /ironic/driver-requirements.txt',
     'ironic-staging-drivers',
+    'ironic-prometheus-exporter',
 ] %}
 
 RUN {{ macros.install_pip(ironic_conductor_pip_packages | customizable("pip_packages")) }}

--- a/docker/prometheus/prometheus-ironic-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-ironic-exporter/Dockerfile.j2
@@ -1,0 +1,26 @@
+FROM {{ namespace }}/{{ image_prefix }}prometheus-base:{{ tag }}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+
+{% block ironic_exporter_header %}{% endblock %}
+
+{% import "macros.j2" as macros with context %}
+
+{% if base_package_type == 'rpm' %}
+   {% set ironic_exporter_packages = ['gcc','python3-devel'] %}
+{% elif base_package_type == 'deb' %}
+   {% set ironic_exporter_packages = ['gcc','python3-dev'] %}
+{% endif %}
+
+{{ macros.install_packages(ironic_exporter_packages | customizable("packages")) }}
+
+{% set ironic_exporter_pip_packages = [
+   'ironic-prometheus-exporter',
+   'gunicorn',
+] %}
+
+RUN {{ macros.install_pip( ironic_exporter_pip_packages | customizable("pip_packages"), constraints=false ) }}
+
+{% block ironic_exporter_footer %}{% endblock %}
+{% block footer %}{% endblock %}
+
+USER prometheus


### PR DESCRIPTION
This adds the prometheus-ironic-exporter container, as well as the prometheus ironic exporter messaging driver to ironic-conductor. 