### PR TITLE
horizon: pin pip to <25.3

### DIFF
--- a/docker/horizon/Dockerfile.j2
+++ b/docker/horizon/Dockerfile.j2
@@ -47,6 +47,7 @@ COPY extend_start.sh /usr/local/bin/kolla_extend_start
 
 # NOTE(hrw): to install horizon from unpacked sources we cannot have it in upper-constraints.txt
 RUN ln -s horizon-source/* horizon \
+    && {{ macros.install_pip(['pip==25.2.*']) }} \
     && {{ macros.upper_constraints_remove("horizon") }} \
     && {{ macros.install_pip(horizon_pip_packages | customizable("pip_packages")) }} \
     && mkdir -p /etc/openstack-dashboard \


### PR DESCRIPTION
backport fix to fix horizon build by pinning pip version: https://bugs.launchpad.net/kolla/+bug/2129916