### PR TITLE
Transition to the new rabbitmq Debian package archives.

### DIFF
--- a/docker/base/Dockerfile.j2
+++ b/docker/base/Dockerfile.j2
@@ -284,7 +284,7 @@ COPY apt_preferences /etc/apt/preferences.d/kolla-custom
 
 {% set base_apt_keys = [
    {'name': 'erlang-ppa', 'keyid': 'F77F1EDA57EBB1CC'},
-   {'name': 'rabbitmq',   'keyid': '9F4587F226208342'},
+   {'name': 'rabbitmq',   'keyid': '6B73A36E6026DFCA'},
    {'name': 'haproxy',    'keyid': 'CFFB779AADC995E4F350A060505D97A41C61B9CD'},
 ] %}
 

--- a/kolla/template/repos.yaml
+++ b/kolla/template/repos.yaml
@@ -77,7 +77,7 @@ debian:
     component: ""
     gpg_key: "proxysql.asc"
   rabbitmq:
-    url: "https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/debian"
+    url: "https://deb1.rabbitmq.com/rabbitmq-server/debian/bullseye"
     suite: "bullseye"
     component: "main"
     gpg_key: "rabbitmq.gpg"
@@ -129,7 +129,7 @@ debian-aarch64:
     component: ""
     gpg_key: "proxysql.asc"
   rabbitmq:
-    url: "https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/debian"
+    url: "https://deb1.rabbitmq.com/rabbitmq-server/debian/bullseye"
     suite: "bullseye"
     component: "main"
     arch: "amd64"
@@ -218,7 +218,7 @@ ubuntu:
     component: ""
     gpg_key: "proxysql.asc"
   rabbitmq:
-    url: "https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu"
+    url: "https://deb1.rabbitmq.com/rabbitmq-server/ubuntu/jammy"
     suite: "jammy"
     component: "main"
     gpg_key: "rabbitmq.gpg"
@@ -270,7 +270,7 @@ ubuntu-aarch64:
     component: ""
     gpg_key: "proxysql.asc"
   rabbitmq:
-    url: "https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu"
+    url: "https://deb1.rabbitmq.com/rabbitmq-server/ubuntu/jammy"
     suite: "jammy"
     component: "main"
     arch: "amd64"

--- a/kolla/tests/test_methods.py
+++ b/kolla/tests/test_methods.py
@@ -85,8 +85,8 @@ class MethodsTest(base.TestCase):
             'base_package_type': 'deb'
         }
 
-        result = methods.handle_repos(template_vars, ['rabbitmq'], 'enable')
-        expectCmd = "RUN echo 'Uris: https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/debian' "  # noqa: E501
+        result = methods.handle_repos(template_vars, ["rabbitmq"], "enable")
+        expectCmd = "RUN echo 'Uris: https://deb1.rabbitmq.com/rabbitmq-server/debian/bullseye' "  # noqa: E501
         expectCmd += ">/etc/apt/sources.list.d/rabbitmq.sources && "
         expectCmd += "echo 'Components: main' "
         expectCmd += ">>/etc/apt/sources.list.d/rabbitmq.sources && "
@@ -133,7 +133,7 @@ class MethodsTest(base.TestCase):
         expectCmd += ">>/etc/apt/sources.list.d/grafana.sources && "
 
         expectCmd += "echo 'Uris: "
-        expectCmd += "https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/debian' "  # noqa: E501
+        expectCmd += "https://deb1.rabbitmq.com/rabbitmq-server/debian/bullseye' "  # noqa: E501
         expectCmd += ">/etc/apt/sources.list.d/rabbitmq.sources && "
         expectCmd += "echo 'Components: main' "
         expectCmd += ">>/etc/apt/sources.list.d/rabbitmq.sources && "

--- a/releasenotes/notes/handle-deprecated-rabbitmq-package-archive-47548e7a41baa68b.yaml
+++ b/releasenotes/notes/handle-deprecated-rabbitmq-package-archive-47548e7a41baa68b.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    `As announced in July 2025 <https://www.rabbitmq.com/blog/2025/07/16/debian-apt-repositories-are-moving>`__,
+    the RabbitMQ project has changed the location and signing key for their Debian and
+    Ubuntu packages. The repository configuration has been updated accordingly.
+    `LP#2131736 <https://launchpad.net/bugs/2131736>`__


### PR DESCRIPTION
RabbitMQ announced some time ago that the package archives were moving: https://www.rabbitmq.com/blog/2025/07/16/debian-apt-repositories-are-moving

The old location is no longer working, so this patch transitions to the new one.

Closes-Bug: #2131736

Change-Id: I6ef0ed9cc40be42a0d98c6a4c83c5c5c26d9cdbf Signed-off-by: Michael Still <mikal@stillhq.com> (cherry picked from commit 0fc73a644bdb7e4f583ba5ebf7ee3fcd60fb8ffc)