### PR TITLE
Make build context archives reproducible

### DIFF
--- a/kolla/image/tasks.py
+++ b/kolla/image/tasks.py
@@ -32,6 +32,21 @@ class ArchivingError(Exception):
     pass
 
 
+def normalize_tarinfo(tarinfo):
+    # NOTE(mgoddard): Change ownership of files to root:root. This
+    # avoids an issue introduced by the fix for git CVE-2022-24765,
+    # which breaks PBR when the source checkout is not owned by the
+    # user installing it. LP#1969096
+    tarinfo.uid = tarinfo.gid = 0
+    tarinfo.uname = tarinfo.gname = "root"
+    # Pin mtime so archive bytes do not depend on checkout/extraction
+    # time, keeping the engine's layer cache valid when the content is
+    # unchanged. An integer mtime also stops tarfile's PAX writer
+    # emitting per-entry float-mtime extended headers.
+    tarinfo.mtime = 0
+    return tarinfo
+
+
 class EngineTask(task.Task):
     def __init__(self, conf):
         super(EngineTask, self).__init__()
@@ -167,15 +182,6 @@ class BuildTask(EngineTask):
 
         dest_archive = os.path.join(image.path, source['name'] + '-archive')
 
-        # NOTE(mgoddard): Change ownership of files to root:root. This
-        # avoids an issue introduced by the fix for git CVE-2022-24765,
-        # which breaks PBR when the source checkout is not owned by the
-        # user installing it. LP#1969096
-        def reset_userinfo(tarinfo):
-            tarinfo.uid = tarinfo.gid = 0
-            tarinfo.uname = tarinfo.gname = "root"
-            return tarinfo
-
         if source.get('type') == 'url':
             self.logger.debug("Getting archive from %s", source['source'])
             try:
@@ -223,7 +229,7 @@ class BuildTask(EngineTask):
 
             with tarfile.open(dest_archive, 'w') as tar:
                 tar.add(clone_dir, arcname=os.path.basename(clone_dir),
-                        filter=reset_userinfo)
+                        filter=normalize_tarinfo)
 
         elif source.get('type') == 'local':
             self.logger.debug("Getting local archive from %s",
@@ -232,7 +238,7 @@ class BuildTask(EngineTask):
                 with tarfile.open(dest_archive, 'w') as tar:
                     tar.add(source['source'],
                             arcname=os.path.basename(source['source']),
-                            filter=reset_userinfo)
+                            filter=normalize_tarinfo)
             else:
                 shutil.copyfile(source['source'], dest_archive)
 
@@ -304,17 +310,9 @@ class BuildTask(EngineTask):
                         raise ArchivingError
             arc_path = os.path.join(image.path, '%s-archive' % arcname)
 
-            # NOTE(jneumann): Change ownership of files to root:root. This
-            # avoids an issue introduced by the fix for git CVE-2022-24765,
-            # which breaks PBR when the source checkout is not owned by the
-            # user installing it. LP#1969096
-            def reset_userinfo(tarinfo):
-                tarinfo.uid = tarinfo.gid = 0
-                tarinfo.uname = tarinfo.gname = "root"
-                return tarinfo
-
             with tarfile.open(arc_path, 'w') as tar:
-                tar.add(items_path, arcname=arcname, filter=reset_userinfo)
+                tar.add(items_path, arcname=arcname,
+                        filter=normalize_tarinfo)
             return len(os.listdir(items_path))
 
         self.logger.debug('Processing')

--- a/kolla/tests/test_build.py
+++ b/kolla/tests/test_build.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import fixtures
+import io
 import os
 import requests
 import sys
@@ -322,6 +323,67 @@ class TasksTest(base.TestCase):
         finally:
             os.umask(saved_umask)
             os.rmdir(tmpdir)
+
+    @mock.patch.dict(os.environ, clear=True)
+    @mock.patch('docker.APIClient')
+    def test_local_directory_archive_reproducible(self, mock_client):
+        src_dir = self.useFixture(fixtures.TempDir()).path
+        sub_dir = os.path.join(src_dir, 'sub')
+        os.mkdir(sub_dir)
+        file_path = os.path.join(sub_dir, 'test.txt')
+        with open(file_path, 'w') as f:
+            f.write('Hello')
+
+        source = {'name': 'fake-image-base',
+                  'type': 'local',
+                  'enabled': True,
+                  'source': src_dir}
+        push_queue = mock.Mock()
+
+        archives = []
+        for mtime in (1000000000, 2000000000):
+            os.utime(file_path, (mtime, mtime))
+            os.utime(sub_dir, (mtime, mtime))
+            os.utime(src_dir, (mtime, mtime))
+            image = FAKE_IMAGE.copy()
+            image.path = self.useFixture(fixtures.TempDir()).path
+            builder = tasks.BuildTask(self.conf, image, push_queue)
+            dest_archive = builder.process_source(image, source)
+            self.assertIsNotNone(dest_archive)
+            with open(dest_archive, 'rb') as f:
+                archives.append(f.read())
+
+        self.assertEqual(archives[0], archives[1])
+        with tarfile.open(fileobj=io.BytesIO(archives[0])) as tar:
+            for member in tar.getmembers():
+                self.assertEqual(0, member.mtime)
+                self.assertEqual(0, member.uid)
+                self.assertEqual(0, member.gid)
+                self.assertEqual('root', member.uname)
+                self.assertEqual('root', member.gname)
+
+    @mock.patch.dict(os.environ, clear=True)
+    @mock.patch('docker.APIClient')
+    def test_empty_plugins_archive_reproducible(self, mock_client):
+        self.dc = mock_client
+        push_queue = mock.Mock()
+
+        archives = []
+        for _ in range(2):
+            image = FAKE_IMAGE.copy()
+            image.path = self.useFixture(fixtures.TempDir()).path
+            builder = tasks.BuildTask(self.conf, image, push_queue)
+            builder.run()
+            self.assertTrue(builder.success)
+            with open(os.path.join(image.path, 'plugins-archive'),
+                      'rb') as f:
+                archives.append(f.read())
+
+        self.assertEqual(archives[0], archives[1])
+        with tarfile.open(fileobj=io.BytesIO(archives[0])) as tar:
+            members = tar.getmembers()
+            self.assertEqual(['plugins'], [m.name for m in members])
+            self.assertEqual(0, members[0].mtime)
 
     @mock.patch.dict(os.environ, clear=True)
     @mock.patch('docker.APIClient')

--- a/releasenotes/notes/reproducible-context-archives-9f3b1c47d2a85e60.yaml
+++ b/releasenotes/notes/reproducible-context-archives-9f3b1c47d2a85e60.yaml
@@ -1,0 +1,17 @@
+---
+fixes:
+  - |
+    Archives added to the image build context (``plugins-archive``,
+    ``additions-archive`` and archives built from ``local`` directory
+    sources) are now reproducible: file modification times are pinned
+    to the Unix epoch, in addition to the existing root:root ownership
+    normalisation. Previously these archives changed on every build
+    even with unchanged content, invalidating the container engine's
+    layer cache for every image consuming them.
+    `LP#1839319 <https://bugs.launchpad.net/kolla/+bug/1839319>`__
+upgrade:
+  - |
+    Files extracted from ``plugins-archive``, ``additions-archive`` and
+    ``local`` directory source archives now have a modification time of
+    0 (Unix epoch). The first build after upgrading will not match
+    previously cached layers for these archives.


### PR DESCRIPTION
The plugins, additions and local directory source archives embedded file modification times from the source checkout, so the archive bytes changed on every build even when the content did not. This invalidated the container engine's layer cache for ADD instructions consuming them, including the empty plugins-archive and additions-archive added to every image.

This change pins the mtime of all archive members to a fixed integer value, and combines the two existing `reset_userinfo` definitions and new mtime fix into a single `normalize_tarinfo` filter.

The chosen mtime value is the unix epoch for two reasons: it's a convention for reproducible builds, and pinning to an integer prevents python's tarfile from emitting extended PAX mtime headers.

This does not make archives of git-sourced plugins reproducible, since the .git directory content itself differs between clones.

Partial-Bug: #1839319
Change-Id: I91b42fe530f87af7d78bb1a543b29a4b0d50872e

(cherry picked from commit ccc06df2a2c146513c696ace2e5bf13d84d6be89)