### PR TITLE
Update repo GPG key for influxdata.

### DIFF
--- a/docker/base/Dockerfile.j2
+++ b/docker/base/Dockerfile.j2
@@ -291,7 +291,7 @@ COPY apt_preferences /etc/apt/preferences.d/kolla-custom
 {# NOTE(hrw): type field defaults to 'asc' which is used for single keys #}
 {% set base_remote_apt_keys = [
    {'name': 'grafana', 'url': 'https://rpm.grafana.com/gpg.key'},
-   {'name': 'influxdb', 'url': 'https://repos.influxdata.com/influxdata-archive_compat.key'},
+   {'name': 'influxdb', 'url': 'https://repos.influxdata.com/influxdata-archive.key'},
    {'name': 'mariadb', 'url': 'https://downloads.mariadb.com/MariaDB/mariadb-keyring-2019.gpg', 'type': 'gpg'},
    {'name': 'opensearch', 'url': 'https://artifacts.opensearch.org/publickeys/opensearch.pgp'},
    {'name': 'proxysql', 'url': 'https://repo.proxysql.com/ProxySQL/proxysql-2.4.x/repo_pub_key'},

--- a/docker/base/influxdb.repo
+++ b/docker/base/influxdb.repo
@@ -3,4 +3,4 @@ name = InfluxDB Repository - RHEL $releasever
 baseurl = https://repos.influxdata.com/rhel/$releasever/$basearch/stable
 enabled = 0
 gpgcheck = 1
-gpgkey = https://repos.influxdata.com/influxdata-archive_compat.key
+gpgkey = https://repos.influxdata.com/influxdata-archive.key

--- a/releasenotes/notes/influxdb-repo-gpg-key-04eb924f249e54a5.yaml
+++ b/releasenotes/notes/influxdb-repo-gpg-key-04eb924f249e54a5.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Updates the InfluxDB repository GPG key from the expired
+    ``influxdata-archive_compat.key`` to the recommended
+    ``influxdata-archive.key`` as per https://repos.influxdata.com.


### PR DESCRIPTION
According to https://www.influxdata.com/blog/package-signing-key-rotation the preferred signing key for influxdata package repositories changed in early 2026. Update to the new preferred key.

Closes-Bug: #2138095

Change-Id: I77d38e713678ea653ded3b14fd0541d3ec0ebee6

(cherry picked from commit b852b8ce32a53cd747d8385e6185d2ad521dee5d) (cherry picked from commit 2056cf2c5093ea2b92d01600c72ba3e6105ca71a)